### PR TITLE
Update conda_build_config.yaml

### DIFF
--- a/opensim/conda_build_config.yaml
+++ b/opensim/conda_build_config.yaml
@@ -16,3 +16,7 @@ cxx_compiler:
 CONDA_BUILD_SYSROOT:
   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
 
+c_compiler_version:
+  - 7.5.0  # [linux]
+cxx_compiler_version:
+  - 7.5.0  # [linux]


### PR DESCRIPTION
Specified version 7.5.0 for gcc and g++, to make it compatible with colab.

This solves the GLIBCXX_3.4.29 by downgrading the version of the compilers in conda-opensim (without moco).